### PR TITLE
Fix: Time/Spread crackling: audio block size 4 → 16

### DIFF
--- a/TimeMachine/TimeMachine.cpp
+++ b/TimeMachine/TimeMachine.cpp
@@ -199,7 +199,7 @@ int main(void)
 {
 	// init time machine hardware
 	hw.Init();
-	hw.SetAudioBlockSize(4); // number of samples handled per callback
+	hw.SetAudioBlockSize(16); // number of samples handled per callback
 
 	dsy_gpio_pin gatePin = DaisyPatchSM::B9;
 	gate.Init(&gatePin);


### PR DESCRIPTION
Block size 4 amortized fixed per-callback overhead (control reads,
slewer ticks, spreadTaps with pow() calls, biquad reconfigures) over
only 4 samples — too few to keep up with CPU/cache pressure under
long-delay conditions where scattered SDRAM reads defeat the D-cache.
Audible as sample-rate clicks past noon on Time and Spread, worst on
Time which scales the whole delay range.

Bug class first reproduced and characterized on the Tap-O-Matic
(github.com/cormallen/tap-o-matic, a fork of this firmware that bumped
block size 4 → 7 but stayed below the cliff). Measured CPU there with
the existing cpuMeter at Time max + Spread max + feedback off,
sustained tonal input:

  block 7:  ~89% AVG / ~100%+ MAX  cracks (Tap-O-Matic original)
  block 8:   84% / 95%             cracks
  block 10:  75% / 87%             clean
  block 12:  72% / 80%             clean
  block 16:  64% / 76%             clean (chosen)
  block 48:  52% / 57%             clean (Daisy default)

OAM Time Machine is structurally identical (same ReadHead crossfade
design, same audio callback pattern) with the block size set even
more aggressively at 4, so the same cliff applies more severely.
Block 16 confirmed audibly clean on OAM Time Machine hardware (Daisy
Patch SM in Tiptop Mantis case) with sustained tonal input: full Time
and Spread sweeps, varying feedback levels, multiple tap-slider
combinations, with and without CV modulation on Spread. Previously
consistent crackling now silent.

Latency cost vs original block 4 is roughly 0.5 ms.
